### PR TITLE
Update database.js

### DIFF
--- a/dev/server/database.js
+++ b/dev/server/database.js
@@ -30,5 +30,3 @@ exports.addUser = function(userName) {
             done();
         });
 };
-
-pgp.end();


### PR DESCRIPTION
Looks like a misunderstanding of what `pgp.end()` does and why or where to use it. See [Library De-initilization](https://github.com/vitaly-t/pg-promise#library-de-initialization)

And in a context like this one it will do precisely nothing. You are trying to shut down the database connection pool before it is even used for the first time. Best advise - don't use it at all, it is not necessary.
